### PR TITLE
Optimize generate ratings mapping

### DIFF
--- a/movie_rec/lib/moviereviews.py
+++ b/movie_rec/lib/moviereviews.py
@@ -17,7 +17,9 @@ class MovieReviews(object):
         ratings = {}
 
         for review in self.reviews:
-            rating = { review['critic']: { review['movie']: int(review['rating']) } }
-            ratings.update(rating)
+            critic_name = review['critic']
+            critic_ratings = ratings.get(critic_name, {})
+            critic_ratings.update({ review['movie']: int(review['rating']) })
+            ratings[critic_name] = critic_ratings
 
         return ratings

--- a/movie_rec/lib/moviereviews.py
+++ b/movie_rec/lib/moviereviews.py
@@ -14,15 +14,10 @@ class MovieReviews(object):
             return [line.rstrip() for line in f]
 
     def critic_rating_mapping(self):
-        return dict([
-            (critic, self.ratings_for_critic(critic))
-            for critic in self.critics
-        ])
+        ratings = {}
 
-    def ratings_for_critic(self, critic):
-        return dict([
-            (review['movie'], int(review['rating']))
-            for review in self.reviews
-            if critic == review['critic']
-        ])
+        for review in self.reviews:
+            rating = { review['critic']: { review['movie']: int(review['rating']) } }
+            ratings.update(rating)
 
+        return ratings


### PR DESCRIPTION
This way, we iterate through all reviews once, instead of once per critic. Can you verify that the behavior is still correct and that it is actually faster?