### PR TITLE
Add script to calculate accuracy

### DIFF
--- a/movie_rec/lib/mlhelper.py
+++ b/movie_rec/lib/mlhelper.py
@@ -15,7 +15,7 @@ def create_test_inputs_matrix(critics, review_mapping):
             array[i] = rating
             test_inputs[movie] = array
 
-    return np.array(test_inputs.values())
+    return test_inputs.keys(), np.array(test_inputs.values())
 
 def create_inputs_row(movie, critics, review_mapping):
     return [add_rating(critic, movie, review_mapping) for critic in critics]

--- a/movie_rec/movie_rec.py
+++ b/movie_rec/movie_rec.py
@@ -6,9 +6,16 @@ from lib.moviereviews import MovieReviews
 from lib.mlhelper import create_inputs_matrix, create_test_inputs_matrix, create_target_matrix
 from lib.multi_class import one_vs_all, predict_all
 
+
 def load_data(filename):
     with open(filename) as f:
         return [line.rstrip() for line in f]
+
+
+def save_data(data, output):
+    with open(output, 'w') as f:
+        f.write("\n".join(["{}\t{}".format(*item) for item in data]))
+
 
 if __name__ == '__main__':
     # parse options. inputs <-
@@ -19,6 +26,8 @@ if __name__ == '__main__':
                       help="examples of positive target values")
     parser.add_option("-n", "--negative", dest="negative", metavar="PATH",
                       help="examples of negative target values")
+    parser.add_option("-o", "--output", dest="output", metavar="PATH",
+                      help="path of hypothesis")
     (options, args) = parser.parse_args()   
    
     # load data 
@@ -44,7 +53,7 @@ if __name__ == '__main__':
     )
 
     print "creating test inputs matrix"
-    X_test = create_test_inputs_matrix(
+    movies, X_test = create_test_inputs_matrix(
         movie_reviews.critics,
         movie_reviews.critic_ratings
     )
@@ -57,7 +66,8 @@ if __name__ == '__main__':
     all_theta = one_vs_all(X, Y, num_classifications, learning_rate)
 
     print "predicting"
-    hypothesis = predict_all(X_test, all_theta)
+    hypothesis = [x[0] for x in predict_all(X_test, all_theta).tolist()]
 
-    # output
-    print hypothesis
+    print "saving hypothesis"
+    save_data(zip(movies, hypothesis), options.output)
+

--- a/movie_rec/scripts/split_equal_pieces
+++ b/movie_rec/scripts/split_equal_pieces
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+input_path=$1
+file_name=$2
+
+line_count=$(wc -l < $input_path)
+part_size=$(printf "%.0f" $(echo ".2*$line_count" | bc ))
+
+split -l $part_size $input_path $file_name.
+mv $file_name.* data/part_files
+
+mv data/part_files/$file_name.aa data/cv/$file_name
+mv data/part_files/$file_name.ab data/test/$file_name
+cat data/part_files/$file_name.* > data/training/$file_name
+rm data/part_files/*

--- a/movie_rec/test_accuracy.py
+++ b/movie_rec/test_accuracy.py
@@ -1,0 +1,42 @@
+from optparse import OptionParser
+
+def load_data(filename):
+    with open(filename) as f:
+        return [line.rstrip() for line in f]
+
+def load_predictions(filename):
+    hypothesis = {}
+    data = load_data(filename)
+    for prediction in data:
+        movie, rating = prediction.split("\t")
+        hypothesis[movie] = rating
+    return hypothesis 
+
+def evaluate_accuracy(predictions, positives, negatives):
+    correct  = 0
+    total = len(positives) + len(negatives)
+
+    pos_correct = sum([ 1 if predictions[movie] == '1' else 0 for movie in positives])
+    neg_correct = sum([ 1 if predictions[movie] == '2' else 0 for movie in negatives])
+    correct = pos_correct + neg_correct
+
+    print "\nModel accurately predicted {} / {}".format(correct, total)
+    print "Accuracy: {0:.1f}%\n".format((correct / float(total)) * 100)
+
+
+if __name__ == '__main__':
+    # parse options. inputs <-
+    parser = OptionParser()
+    parser.add_option("-i", "--input", dest="input", metavar="PATH",
+                      help="path to predicted classes")
+    parser.add_option("-p", "--positive", dest="positive", metavar="PATH",
+                      help="path to positive test set")
+    parser.add_option("-n", "--negative", dest="negative", metavar="PATH",
+                      help="path to negative test set")
+    (options, args) = parser.parse_args()   
+   
+    predictions = load_predictions(options.input)
+    positives = load_data(options.positive)
+    negatives = load_data(options.negative)
+    evaluate_accuracy(predictions, positives, negatives) 
+


### PR DESCRIPTION
wrote a script that can break the annotations up into 5 parts. I'm then moving 1/5 to a cv (cross-validation) directory and 1/5 to a test directory and the rest to training set. The movie_rec.py should point to train/neg and train/pos. 

`python test_accuracy.py -i output/hypothesis.tsv -p data/cv/pos -n data/cv/neg`